### PR TITLE
Cache client tools for admin UI

### DIFF
--- a/db/drizzle/0112_cached_client_tools.sql
+++ b/db/drizzle/0112_cached_client_tools.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS "cached_client_tools" (
+    "id" bigserial PRIMARY KEY,
+    "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+    "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
+    "customer_email" text,
+    "platform_customer_id" bigint,
+    "tools" jsonb NOT NULL
+);
+
+CREATE INDEX "cached_client_tools_customer_idx" ON "cached_client_tools" ("customer_email");
+CREATE INDEX "cached_client_tools_platform_customer_idx" ON "cached_client_tools" ("platform_customer_id");
+
+ALTER TABLE "cached_client_tools" ENABLE ROW LEVEL SECURITY;

--- a/db/drizzle/meta/_journal.json
+++ b/db/drizzle/meta/_journal.json
@@ -785,6 +785,13 @@
       "when": 1754335661899,
       "tag": "0111_parallel_rumiko_fujikawa",
       "breakpoints": true
+    },
+    {
+      "idx": 112,
+      "version": "7",
+      "when": 1754335700000,
+      "tag": "0112_cached_client_tools",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema/cachedClientTools.ts
+++ b/db/schema/cachedClientTools.ts
@@ -1,0 +1,20 @@
+import { bigint, index, jsonb, pgTable, text } from "drizzle-orm/pg-core";
+import { withTimestamps } from "../lib/with-timestamps";
+import { ToolRequestBody } from "@helperai/client";
+
+export const cachedClientTools = pgTable(
+  "cached_client_tools",
+  {
+    ...withTimestamps,
+    id: bigint({ mode: "number" }).primaryKey().generatedByDefaultAsIdentity(),
+    customerEmail: text(),
+    platformCustomerId: bigint("platform_customer_id", { mode: "number" }),
+    tools: jsonb().$type<Record<string, ToolRequestBody>>().notNull(),
+  },
+  (table) => [
+    index("cached_client_tools_customer_idx").on(table.customerEmail),
+    index("cached_client_tools_platform_customer_idx").on(table.platformCustomerId),
+  ],
+).enableRLS();
+
+export type CachedClientTools = typeof cachedClientTools.$inferSelect;

--- a/db/schema/index.ts
+++ b/db/schema/index.ts
@@ -21,3 +21,4 @@ export * from "./jobRuns";
 export * from "./userProfiles";
 export * from "./savedReplies";
 export * from "./issueGroups";
+export * from "./cachedClientTools";

--- a/lib/data/clientTools.ts
+++ b/lib/data/clientTools.ts
@@ -1,0 +1,70 @@
+import "server-only";
+import { and, eq, isNull } from "drizzle-orm";
+import { db } from "@/db/client";
+import { cachedClientTools, platformCustomers } from "@/db/schema";
+import { ToolRequestBody } from "@helperai/client";
+
+export const cacheClientTools = async (
+  tools: Record<string, ToolRequestBody> | undefined,
+  customerEmail?: string | null,
+) => {
+  if (!tools) return;
+  const serverTools = Object.fromEntries(
+    Object.entries(tools).filter(([, tool]) => tool.serverRequestUrl),
+  );
+  if (Object.keys(serverTools).length === 0) return;
+
+  let platformCustomerId: number | null = null;
+  if (customerEmail) {
+    const platformCustomer = await db.query.platformCustomers.findFirst({
+      columns: { id: true },
+      where: eq(platformCustomers.email, customerEmail),
+    });
+    platformCustomerId = platformCustomer?.id ?? null;
+  }
+
+  await db.transaction(async (tx) => {
+    if (customerEmail) {
+      await tx
+        .delete(cachedClientTools)
+        .where(eq(cachedClientTools.customerEmail, customerEmail));
+      await tx.insert(cachedClientTools).values({
+        customerEmail,
+        platformCustomerId,
+        tools: serverTools,
+      });
+    } else {
+      await tx
+        .delete(cachedClientTools)
+        .where(
+          and(
+            isNull(cachedClientTools.customerEmail),
+            isNull(cachedClientTools.platformCustomerId),
+          ),
+        );
+      await tx.insert(cachedClientTools).values({
+        customerEmail: null,
+        platformCustomerId: null,
+        tools: serverTools,
+      });
+    }
+  });
+};
+
+export const getCachedClientTools = async (
+  customerEmail?: string | null,
+): Promise<Record<string, ToolRequestBody> | null> => {
+  if (customerEmail) {
+    const record = await db.query.cachedClientTools.findFirst({
+      where: eq(cachedClientTools.customerEmail, customerEmail),
+    });
+    if (record) return record.tools as Record<string, ToolRequestBody>;
+  }
+  const globalRecord = await db.query.cachedClientTools.findFirst({
+    where: and(
+      isNull(cachedClientTools.customerEmail),
+      isNull(cachedClientTools.platformCustomerId),
+    ),
+  });
+  return globalRecord ? (globalRecord.tools as Record<string, ToolRequestBody>) : null;
+};

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -233,9 +233,11 @@ export class HelperClient {
     handler: ({
       conversation,
       tools = {},
+      customerSpecificTools,
     }: {
       conversation: ConversationDetails;
       tools?: Record<string, HelperTool>;
+      customerSpecificTools?: boolean;
     }) => {
       const formattedMessages = conversation.messages.map(formatAIMessage);
 
@@ -293,6 +295,7 @@ export class HelperClient {
           conversationSlug: conversation.slug,
           tools: serializeTools(tools),
           requestBody,
+          customerSpecificTools,
         }),
         onToolCall: ({ toolCall }: { toolCall: { toolName: string; args: unknown } }) => {
           const tool = tools[toolCall.toolName];

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -41,6 +41,7 @@ export const createMessageBodySchema = z.object({
     )
     .optional(),
   tools: z.record(z.string(), toolBodySchema).optional(),
+  customerSpecificTools: z.boolean().optional(),
 });
 export type CreateMessageRequestBody = z.infer<typeof createMessageBodySchema>;
 export type CreateMessageParams = Omit<CreateMessageRequestBody, "attachments" | "tools"> & {

--- a/packages/react/src/hooks/useChat.ts
+++ b/packages/react/src/hooks/useChat.ts
@@ -10,6 +10,7 @@ export interface UseChatProps {
   conversation: ConversationDetails;
   tools?: Record<string, HelperTool>;
   enableRealtime?: boolean;
+  customerSpecificTools?: boolean;
   ai?: Parameters<typeof useAIChat>[0];
 }
 
@@ -23,12 +24,16 @@ export const useChat = ({
   conversation,
   tools = {},
   enableRealtime = true,
+  customerSpecificTools,
   ai: aiOptions,
 }: UseChatProps): UseChatResult => {
   const { client } = useHelperClient();
   const [agentTyping, setAgentTyping] = useState(false);
 
-  const chatHandler = useMemo(() => client.chat.handler({ conversation, tools }), [client, conversation, tools]);
+  const chatHandler = useMemo(
+    () => client.chat.handler({ conversation, tools, customerSpecificTools }),
+    [client, conversation, tools, customerSpecificTools],
+  );
 
   const { messages, setMessages, ...rest } = useAIChat({
     ...chatHandler,


### PR DESCRIPTION
## Summary
- add cached_client_tools table to store server tools by customer
- cache client-provided tools on chat and message endpoints with optional customerSpecificTools flag
- expose cached tools in conversation tools list and update client/react APIs accordingly

## Testing
- `pnpm test:unit` *(fails: Could not find a working container runtime strategy)*

------
https://chatgpt.com/codex/tasks/task_e_6896c23494408328af7722499a81d367