### PR TITLE
test: add coverage for client tools and chat route

### DIFF
--- a/tests/app/api/chat/conversation/[slug]/message/route.test.ts
+++ b/tests/app/api/chat/conversation/[slug]/message/route.test.ts
@@ -61,6 +61,41 @@ describe("POST /api/chat/conversation/[slug]/message", () => {
     );
   });
 
+  it("should forward tools to triggerEvent", async () => {
+    const { mailbox } = await mailboxFactory.create();
+    const { conversation } = await conversationFactory.create({
+      emailFrom: "test@example.com",
+    });
+
+    mockSession = { isAnonymous: false, email: "test@example.com" };
+    mockMailbox = mailbox;
+
+    const tools = {
+      weather: {
+        description: "Fetch weather",
+        parameters: { location: { type: "string" } },
+      },
+    };
+
+    const request = new Request("https://example.com/api", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "Hello world", tools }),
+    });
+
+    const response = await POST(request, {
+      params: Promise.resolve({ slug: conversation.slug }),
+    });
+    await response.json();
+
+    expect(response.status).toBe(200);
+    expect(triggerEvent).toHaveBeenCalledWith(
+      "conversations/auto-response.create",
+      { messageId: "msg123", tools },
+      { sleepSeconds: 5 * 60 },
+    );
+  });
+
   it("should work with anonymous session", async () => {
     const { mailbox } = await mailboxFactory.create();
     const anonymousSessionId = "anon123";

--- a/tests/lib/data/clientTools.test.ts
+++ b/tests/lib/data/clientTools.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/tools/openApiParser", () => ({
+  parseToolsFromOpenAPISpec: vi.fn(),
+}));
+
+import { fetchOpenApiSpec, getMailboxToolsForChat, importToolsFromSpec } from "@/lib/data/tools";
+import { parseToolsFromOpenAPISpec } from "@/lib/tools/openApiParser";
+import { db } from "@/db/client";
+import { tools as toolsTable, toolApis } from "@/db/schema";
+import { mailboxFactory } from "@tests/support/factories/mailboxes";
+import { toolsFactory } from "@tests/support/factories/tools";
+import { eq } from "drizzle-orm";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("client tools data", () => {
+  it("fetchOpenApiSpec adds Authorization header when apiKey provided", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, text: vi.fn().mockResolvedValue("spec") } as any);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await fetchOpenApiSpec("https://example.com", "key123");
+
+    expect(mockFetch).toHaveBeenCalledWith("https://example.com", {
+      headers: { Authorization: "Bearer key123" },
+    });
+    expect(result).toBe("spec");
+  });
+
+  it("fetchOpenApiSpec throws on HTTP errors", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, statusText: "Bad Request" } as any);
+    vi.stubGlobal("fetch", mockFetch);
+
+    await expect(fetchOpenApiSpec("https://example.com", null)).rejects.toThrow(
+      "Failed to fetch API spec from URL: Bad Request",
+    );
+  });
+
+  it("getMailboxToolsForChat returns only enabled chat tools", async () => {
+    const { tool } = await toolsFactory.create({ enabled: true, availableInChat: true });
+    await toolsFactory.create({ enabled: true, availableInChat: false });
+    await toolsFactory.create({ enabled: false, availableInChat: true });
+
+    const result = await getMailboxToolsForChat();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(tool.id);
+  });
+
+  it("importToolsFromSpec updates existing tools and inserts new ones", async () => {
+    const { mailbox } = await mailboxFactory.create();
+    const [api] = await db
+      .insert(toolApis)
+      .values({ name: "Test API", unused_mailboxId: mailbox.id })
+      .returning({ id: toolApis.id });
+    const toolApiId = api.id;
+
+    await db.insert(toolsTable).values({
+      name: "Old Tool",
+      description: "Old",
+      slug: "existing-tool",
+      requestMethod: "GET",
+      url: "http://old",
+      headers: {},
+      parameters: [],
+      authenticationMethod: "none",
+      authenticationToken: "old-token",
+      toolApiId,
+      enabled: true,
+      availableInChat: true,
+      availableInAnonymousChat: false,
+    });
+
+    vi.mocked(parseToolsFromOpenAPISpec).mockResolvedValue([
+      {
+        name: "Updated Tool",
+        description: "Updated",
+        slug: "existing-tool",
+        requestMethod: "POST",
+        url: "http://new",
+        headers: {},
+        parameters: [],
+        authenticationMethod: "none",
+        authenticationToken: "new-token",
+        enabled: true,
+        availableInChat: true,
+        availableInAnonymousChat: false,
+      },
+      {
+        name: "New Tool",
+        description: "New",
+        slug: "new-tool",
+        requestMethod: "GET",
+        url: "http://newtool",
+        headers: {},
+        parameters: [],
+        authenticationMethod: "none",
+        authenticationToken: "brand-new-token",
+        enabled: true,
+        availableInChat: false,
+        availableInAnonymousChat: false,
+      },
+    ]);
+
+    const result = await importToolsFromSpec({
+      toolApiId,
+      openApiSpec: "{}",
+      apiKey: "api-key",
+    });
+
+    expect(result.toolsToUpdate).toHaveLength(1);
+    expect(result.toolsToInsert).toHaveLength(1);
+
+    const updated = await db.query.tools.findFirst({
+      where: eq(toolsTable.slug, "existing-tool"),
+    });
+    const inserted = await db.query.tools.findFirst({
+      where: eq(toolsTable.slug, "new-tool"),
+    });
+
+    expect(updated?.name).toBe("Updated Tool");
+    expect(updated?.url).toBe("http://new");
+    expect(updated?.authenticationToken).toBe("new-token");
+    expect(inserted?.name).toBe("New Tool");
+    expect(inserted?.toolApiId).toBe(toolApiId);
+    expect(inserted?.authenticationToken).toBe("brand-new-token");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for client tools utilities
- ensure message route forwards provided tools to trigger event

## Testing
- `pnpm test:unit tests/lib/data/clientTools.test.ts tests/app/api/chat/conversation/[slug]/message/route.test.ts` *(fails: Could not find a working container runtime strategy)*

------
https://chatgpt.com/codex/tasks/task_e_689ed39d2e008328a02e05aad069af02